### PR TITLE
Allow access to keyserver behind a restrictive firewall

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -3,7 +3,7 @@
 
 - name: Add Consol Labs repository key
   apt_key: >
-    keyserver=keys.gnupg.net
+    keyserver=hkp://keys.gnupg.net:80
     id=F8C1CA08A57B9ED7
     state=present
   tags: thruk

--- a/templates/thruk_local.conf.j2
+++ b/templates/thruk_local.conf.j2
@@ -293,7 +293,7 @@ backend_debug = 1
 {% else %}
 backend_debug = 0
 {% endif %}
-onnection_pool_size = {{ thruk_connection_pool_size }}
+connection_pool_size = {{ thruk_connection_pool_size }}
 {% if thruk_logcache %}
 logcache = {{ thruk_logcache }}
 {% endif %}


### PR DESCRIPTION
This just specifies that the key search should use http on port 80 to search the keyserver. This allows it to work behind some restrictive firewalls.
